### PR TITLE
Re-added locales.h header

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <inttypes.h>
 #include <ctype.h>
+#include "locales.h"
 #include "parse.h"
 
 keysym_dict_t nks_dict[] = {/*{{{*/


### PR DESCRIPTION
Include locales.h header to fix 'Couldn't retrieve keysym' message
