### PR TITLE
Allow passing LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ VERSION := $(shell $(VERCMD) || cat VERSION)
 
 CPPFLAGS += -D_POSIX_C_SOURCE=200112L -DVERSION=\"$(VERSION)\"
 CFLAGS   += -std=c99 -pedantic -Wall -Wextra
-LDLIBS    = -lxcb -lxcb-keysyms
+LDFLAGS  ?=
+LDLIBS    = $(LDFLAGS) -lxcb -lxcb-keysyms
 
 PREFIX    ?= /usr/local
 BINPREFIX ?= $(PREFIX)/bin


### PR DESCRIPTION
[This is required](http://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/x11/sxhkd/Makefile?rev=HEAD&content-type=text/x-cvsweb-markup) for (at least) OpenBSD where we need to pass `-L/usr/X11R6/lib` to the linker.