### PR TITLE
Add mention of man pages to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,7 @@ The format of the configuration file supports a simple notation for mapping mult
 
 - [vim-sxhkdrc](https://github.com/baskerville/vim-sxhkdrc).
 - [sxhkd-vim](https://github.com/kovetskiy/sxhkd-vim).
+
+----
+
+For further information, check the `man` pages.


### PR DESCRIPTION
The man pages have great information that extends significantly upon what is described here, and I thought it may be a good idea to point users in the right direction that expect a comprehensive summary in the README.