### PR TITLE
Remove explicit mention of xorg.service in sxhkd.service

### DIFF
--- a/contrib/systemd/sxhkd.service
+++ b/contrib/systemd/sxhkd.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Simple X Hotkey Daemon
 Documentation=man:sxhkd(1)
-BindsTo=xorg.service
-After=xorg.service
+BindsTo=display-manager.service
+After=display-manager.service
 
 [Service]
 ExecStart=/usr/bin/sxhkd


### PR DESCRIPTION
Closes #79 and [Red Hat Bug 1528191](https://bugzilla.redhat.com/show_bug.cgi?id=1528191)