### PR TITLE
Feature: Macros for sxhkd (global variables, patterns, etc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,43 @@ The format of the configuration file supports a simple notation for mapping mult
 	super + alt + p
 		bspc config focus_follows_pointer {true,false}
 
+## Macros
+
+The configuration file _may_ contain a set of macros to ease bindings
+definitions. A macro is defined using the keyword `DEF` as follows:
+
+    # A general prefix key for launching applications
+    DEF APP_KEY super + x
+
+    # Rofi shortned.
+    DEF ROFI rofi -matching fuzzy -modi 'window,windowcd,run,drun'
+    DEF MAKE_TIMESTAMP  $(date +%Y-%m-%d_%H%M%S)
+
+    # Icons
+    DEF ICONS_PATH /usr/share/icons/Papirus-Dark/48x48
+    DEF SCROT_ICON {{ICONS_PATH}}/apps/screengrab.svg
+
+In the examples above, `ROFI` is a macro, and its replacement text is `rofi
+-matching fuzzy -modi 'window,windowcd,run,drun'`. Now, we can use `{{ROFI}}`
+anywhere in the configuration file and it will be replaced with the replacement
+text. 
+
+Note also how we have defined a common icons path using the macro `ICONS_PATH`
+and how we have used it to define `SCROT_ICON`. In fact, macros may be defined
+using previously defined macros, and so on.
+
+Using these macros, we can define a binding to take screen shots (using scrot)
+as follows:
+
+    {{APP_KEY}} ; p
+        stamp={{MAKE_TIMESTAMP}};\
+        filename="/tmp/screen_$stamp.png";\
+        scrot $filename;\
+        notify-send -a 'Scrot' "Screenshot taken in $filename" -i {{SCROT_ICON}};
+
+Macros may essentially be used for modularity (See the icons macros above), to
+avoid typing (eg. ROFI), and to define global variables.
+
 ## Editor Plugins
 
 ### Vim

--- a/Sourcedeps
+++ b/Sourcedeps
@@ -8,3 +8,5 @@ sxhkd.o: sxhkd.c grab.h helpers.h parse.h sxhkd.h types.h
 OBJ += sxhkd.o
 types.o: types.c grab.h helpers.h parse.h sxhkd.h types.h
 OBJ += types.o
+macros.o: macros.h macros.c
+OBJ += macros.o

--- a/src/macros.c
+++ b/src/macros.c
@@ -19,15 +19,15 @@
 // Text chunks records {{{
 // States of the FSM for transforming a string using a set of macros.
 enum PARSE_STATE {
-    NORMAL,         // before {{macro}} 
-    MACRO,          // inside {{macro}}
-    POST_MACRO,     // after {{macro}}
+	NORMAL,			// before {{macro}}
+	MACRO,			// inside {{macro}}
+	POST_MACRO,		// after {{macro}}
 };
 
 // Text chunks for text transform.
 typedef struct{
-    int len;
-    char *with;
+	int len;
+	char *with;
 } txt_chunk;
 // }}}
 
@@ -36,295 +36,305 @@ typedef struct{
 // Adapted from:
 // https://github.com/stephane-martin/cycapture/blob/master/cycapture/murmur.c
 // Credit: Stephane Martin
-static FORCE_INLINE uint32_t hash(const void *data, size_t nbytes) {
-    if (data == NULL || nbytes == 0)
-        return 0;
+static FORCE_INLINE uint32_t hash(const void *data, size_t nbytes)
+{
+	if (data == NULL || nbytes == 0)
+		return 0;
 
-    const uint32_t c1 = 0xcc9e2d51;
-    const uint32_t c2 = 0x1b873593;
+	const uint32_t c1 = 0xcc9e2d51;
+	const uint32_t c2 = 0x1b873593;
 
-    const int nblocks = nbytes / 4;
-    const uint32_t *blocks = (const uint32_t *) (data);
-    const uint8_t *tail = (const uint8_t *) data + nblocks * 4;
+	const int nblocks = nbytes / 4;
+	const uint32_t *blocks = (const uint32_t *) (data);
+	const uint8_t *tail = (const uint8_t *) data + nblocks * 4;
 
-    uint32_t h = 0;
+	uint32_t h = 0;
 
-    int i;
-    uint32_t k;
-    for (i = 0; i < nblocks; i++) {
-        k = blocks[i];
+	int i;
+	uint32_t k;
+	for (i = 0; i < nblocks; i++) {
+		k = blocks[i];
 
-        k *= c1;
-        k = (k << 15) | (k >> (32 - 15));
-        k *= c2;
+		k *= c1;
+		k = (k << 15) | (k >> (32 - 15));
+		k *= c2;
 
-        h ^= k;
-        h = (h << 13) | (h >> (32 - 13));
-        h = (h * 5) + 0xe6546b64;
-    }
+		h ^= k;
+		h = (h << 13) | (h >> (32 - 13));
+		h = (h * 5) + 0xe6546b64;
+	}
 
-    k = 0;
-    switch (nbytes & 3) {
-        case 3:
-            k ^= tail[2] << 16;
-        case 2:
-            k ^= tail[1] << 8;
-        case 1:
-            k ^= tail[0];
-            k *= c1;
-            k = (k << 15) | (k >> (32 - 15));
-            k *= c2;
-            h ^= k;
-    };
+	k = 0;
+	switch (nbytes & 3) {
+		case 3:
+			k ^= tail[2] << 16;
+		case 2:
+			k ^= tail[1] << 8;
+		case 1:
+			k ^= tail[0];
+			k *= c1;
+			k = (k << 15) | (k >> (32 - 15));
+			k *= c2;
+			h ^= k;
+	};
 
-    h ^= nbytes;
+	h ^= nbytes;
 
-    h ^= h >> 16;
-    h *= 0x85ebca6b;
-    h ^= h >> 13;
-    h *= 0xc2b2ae35;
-    h ^= h >> 16;
+	h ^= h >> 16;
+	h *= 0x85ebca6b;
+	h ^= h >> 13;
+	h *= 0xc2b2ae35;
+	h ^= h >> 16;
 
-    return h;
+	return h;
 }
 
-static FORCE_INLINE uint32_t hash_to_index(const ht_t *ht, uint32_t h) {
-    return h % ht->size;
+static FORCE_INLINE uint32_t hash_to_index(const ht_t *ht, uint32_t h)
+{
+	return h % ht->size;
 }
 
 // Trim a string left and right and return its new length
-static FORCE_INLINE size_t str_trim(char *src){
-    size_t i = 0;
-    size_t ts = 0;
-    size_t j = safe_strlen(src) - 1;
-    if(src == NULL || j <= 0)
-        return 0;
-    while(j > 0 && isspace(src[j])) j--;
-    while(i <= j && isspace(src[i])) i++;
-    ts = j - i + 1;
-    memcpy(src, src+i, ts);
-    src[ts] = '\0';
-    return ts;
+static FORCE_INLINE size_t str_trim(char *src)
+{
+	size_t i = 0;
+	size_t ts = 0;
+	size_t j = safe_strlen(src) - 1;
+	if(src == NULL || j <= 0)
+		return 0;
+	while(j > 0 && isspace(src[j])) j--;
+	while(i <= j && isspace(src[i])) i++;
+	ts = j - i + 1;
+	memcpy(src, src+i, ts);
+	src[ts] = '\0';
+	return ts;
 }
 
-ht_t *ht_create(const size_t size) {
-    ht_t *ht = malloc(sizeof(ht_t));
-    if(ht == NULL)
-        return ht;
-    ht->size = size;
-    ht->entries = calloc(size, sizeof(macro_t));
-    if(ht->entries == NULL){
-        free(ht);
-        return NULL;
-    }
-    return ht;
+ht_t *ht_create(const size_t size)
+{
+	ht_t *ht = malloc(sizeof(ht_t));
+	if(ht == NULL)
+		return ht;
+	ht->size = size;
+	ht->entries = calloc(size, sizeof(macro_t));
+	if(ht->entries == NULL){
+		free(ht);
+		return NULL;
+	}
+	return ht;
 }
 
-void ht_set(const ht_t *ht, const void *key, const size_t k_len, const void *value, const size_t v_len) {
-    uint32_t h = 0;
-    size_t slot = 0;
-    size_t i = 0;
+void ht_set(const ht_t *ht, const void *key, const size_t k_len, const void *value, const size_t v_len)
+{
+	uint32_t h = 0;
+	size_t slot = 0;
+	size_t i = 0;
 
-    if(ht == NULL || key == NULL || k_len == 0)
-        return;
+	if(ht == NULL || key == NULL || k_len == 0)
+		return;
 
-    h = hash(key, k_len);
+	h = hash(key, k_len);
 
-    for (i = 0; i < ht->size; i++){
-        slot = hash_to_index(ht, (h+1));
-        if(ht->entries[slot].key == NULL){
-            ht->entries[slot].key = malloc(k_len);
-            ht->entries[slot].value = malloc(v_len);
-            memcpy(ht->entries[slot].key, key, k_len);
-            memcpy(ht->entries[slot].value, value, v_len);
-            ht->entries[slot].k_len = k_len;
-            ht->entries[slot].v_len = v_len;
-            break;
-        } else if(k_len == ht->entries[slot].k_len){
-            if(memcmp(ht->entries[slot].key, key, k_len) == 0){
-                free(ht->entries[slot].value);
-                ht->entries[slot].value = malloc(v_len);
-                memcpy(ht->entries[slot].value, value, v_len);
-                ht->entries[slot].k_len = k_len;
-                ht->entries[slot].v_len = v_len;
-                break;
-            }
-        }
-    }
+	for (i = 0; i < ht->size; i++){
+		slot = hash_to_index(ht, (h+1));
+		if(ht->entries[slot].key == NULL){
+			ht->entries[slot].key = malloc(k_len);
+			ht->entries[slot].value = malloc(v_len);
+			memcpy(ht->entries[slot].key, key, k_len);
+			memcpy(ht->entries[slot].value, value, v_len);
+			ht->entries[slot].k_len = k_len;
+			ht->entries[slot].v_len = v_len;
+			break;
+		} else if(k_len == ht->entries[slot].k_len){
+			if(memcmp(ht->entries[slot].key, key, k_len) == 0){
+				free(ht->entries[slot].value);
+				ht->entries[slot].value = malloc(v_len);
+				memcpy(ht->entries[slot].value, value, v_len);
+				ht->entries[slot].k_len = k_len;
+				ht->entries[slot].v_len = v_len;
+				break;
+			}
+		}
+	}
 }
 
-void *ht_get(const ht_t *ht, const void *key, const size_t k_len) {
-    uint32_t h = 0;
-    size_t slot = 0;
+void *ht_get(const ht_t *ht, const void *key, const size_t k_len)
+{
+	uint32_t h = 0;
+	size_t slot = 0;
 
-    if(ht == NULL || key == NULL || k_len == 0)
-        return NULL;
+	if(ht == NULL || key == NULL || k_len == 0)
+		return NULL;
 
-    h = hash(key, k_len);
+	h = hash(key, k_len);
 
-    for (size_t i = 0; i < ht->size; i++){
-        slot = hash_to_index(ht, (h+1));
-        if(ht->entries[slot].key == NULL){
-            return NULL;
-        } else if(k_len == ht->entries[slot].k_len && memcmp(ht->entries[slot].key, key, k_len) == 0){
-            return ht->entries[slot].value;
-        }
-    }
-    return NULL;
+	for (size_t i = 0; i < ht->size; i++){
+		slot = hash_to_index(ht, (h+1));
+		if(ht->entries[slot].key == NULL){
+			return NULL;
+		} else if(k_len == ht->entries[slot].k_len && memcmp(ht->entries[slot].key, key, k_len) == 0){
+			return ht->entries[slot].value;
+		}
+	}
+	return NULL;
 }
 
-void ht_del(const ht_t *ht, const void *key, const size_t k_len) {
-    uint32_t h = 0;
-    size_t slot = 0;
+void ht_del(const ht_t *ht, const void *key, const size_t k_len)
+{
+	uint32_t h = 0;
+	size_t slot = 0;
 
-    if(ht == NULL || key == NULL || k_len == 0)
-        return;
+	if(ht == NULL || key == NULL || k_len == 0)
+		return;
 
-    h = hash(key, k_len);
+	h = hash(key, k_len);
 
-    for (size_t i = 0; i < ht->size; i++){
-        slot = hash_to_index(ht, (h+1));
-        if(ht->entries[slot].key == NULL){
-            break;
-        } else if(k_len == ht->entries[slot].k_len && memcmp(ht->entries[slot].key, key, k_len) == 0){
-            free(ht->entries[slot].key);
-            free(ht->entries[slot].value);
-            ht->entries[slot].key = NULL;
-            ht->entries[slot].value = NULL;
-            ht->entries[slot].k_len = 0;
-            ht->entries[slot].v_len = 0;
-            break;
-        }
-    }
+	for (size_t i = 0; i < ht->size; i++){
+		slot = hash_to_index(ht, (h+1));
+		if(ht->entries[slot].key == NULL){
+			break;
+		} else if(k_len == ht->entries[slot].k_len && memcmp(ht->entries[slot].key, key, k_len) == 0){
+			free(ht->entries[slot].key);
+			free(ht->entries[slot].value);
+			ht->entries[slot].key = NULL;
+			ht->entries[slot].value = NULL;
+			ht->entries[slot].k_len = 0;
+			ht->entries[slot].v_len = 0;
+			break;
+		}
+	}
 }
 
-void ht_destroy(ht_t *ht) {
+void ht_destroy(ht_t *ht)
+{
 
-    if(ht == NULL)
-        return;
+	if(ht == NULL)
+		return;
 
-    for(size_t i=0; i < ht->size; i++){
-        if(ht->entries[i].key != NULL){
-            free(ht->entries[i].key);
-            free(ht->entries[i].value);
-            ht->entries[i].key = NULL;
-            ht->entries[i].value = NULL;
-        }
-    }
+	for(size_t i=0; i < ht->size; i++){
+		if(ht->entries[i].key != NULL){
+			free(ht->entries[i].key);
+			free(ht->entries[i].value);
+			ht->entries[i].key = NULL;
+			ht->entries[i].value = NULL;
+		}
+	}
 
-    free(ht->entries);
-    free(ht);
+	free(ht->entries);
+	free(ht);
 }
 
 // }}}
 
 // {{{ Macros Processor
-char *ht_process_macros(const ht_t *ht, const char * restrict src){
-    enum PARSE_STATE state = NORMAL;
-    size_t i = 0; 
-    size_t last_normal = 0;
-    size_t txt_len = 0;
-    size_t def_len = 0;
-    size_t result_len = 0;
-    size_t with_len = 0;
-    size_t trimmed_len = 0;
-    size_t ch_count = 0;
-    size_t src_len = safe_strlen(src);
-    txt_chunk chunks[MAX_CHUNKS];
-    char def[CHUNK_MAX_LEN] = {0};
-    char *result = NULL;
+char *ht_process_macros(const ht_t *ht, const char * restrict src)
+{
+	enum PARSE_STATE state = NORMAL;
+	size_t i = 0;
+	size_t last_normal = 0;
+	size_t txt_len = 0;
+	size_t def_len = 0;
+	size_t result_len = 0;
+	size_t with_len = 0;
+	size_t trimmed_len = 0;
+	size_t ch_count = 0;
+	size_t src_len = safe_strlen(src);
+	txt_chunk chunks[MAX_CHUNKS];
+	char def[CHUNK_MAX_LEN] = {0};
+	char *result = NULL;
 
-    if(src_len == 0){
-        // Return an empty string anyways.
-        result = malloc(1);
-        result[0] = '\0';
-        return result;
-    }
+	if(src_len == 0){
+		// Return an empty string anyways.
+		result = malloc(1);
+		result[0] = '\0';
+		return result;
+	}
 
-    if(ht == NULL){
-        // No ht, return a copy of src.
-        result = malloc(src_len + 1);
-        if(result != NULL){
-            memcpy(result, src, src_len);
-            result[src_len] = '\0';
-        }
-        return result;
-    }
+	if(ht == NULL){
+		// No ht, return a copy of src.
+		result = malloc(src_len + 1);
+		if(result != NULL){
+			memcpy(result, src, src_len);
+			result[src_len] = '\0';
+		}
+		return result;
+	}
 
-    while(i < src_len){
-        switch (state) {
-            case NORMAL:
-                if(i >= 1 && src[i] == '{' && src[i-1] == '{')
-                    state = MACRO;
-                break;
-            case MACRO:
-                if(src[i] == '}'){
-                    state = POST_MACRO;
-                } else if (src[i] != '{'){
-                    def[def_len++] = src[i];
-                }
-                break;
-            case POST_MACRO:
-                if(src[i] == '}'){
-                    def[def_len] = '\0';
-                    txt_len = i - (def_len + 3) - last_normal;
-                    if(txt_len > 0){
-                        chunks[ch_count].len = txt_len;
-                        chunks[ch_count].with = (char*)src+last_normal;
-                        ch_count++;
-                        result_len += txt_len;
-                    }
-                    // check whether def is a defined macro.
-                    trimmed_len = str_trim(def);
-                    char *with = ht_get(ht, def, trimmed_len + 1);
-                    // Save the macro expansion chunk, if any.
-                    if(with != NULL){
-                        with_len = safe_strlen(with);
-                        chunks[ch_count].len = with_len;
-                        chunks[ch_count].with = with;
-                        ch_count++;
-                        last_normal = i+1;
-                        result_len += with_len;
-                    }
-                } else {
-                    def[0] = '\0';
-                }
-                def_len = 0;
-                state = NORMAL;
-                break;
-        }
-        i++;
-    }
+	while(i < src_len){
+		switch (state) {
+			case NORMAL:
+				if(i >= 1 && src[i] == '{' && src[i-1] == '{')
+					state = MACRO;
+				break;
+			case MACRO:
+				if(src[i] == '}'){
+					state = POST_MACRO;
+				} else if (src[i] != '{'){
+					def[def_len++] = src[i];
+				}
+				break;
+			case POST_MACRO:
+				if(src[i] == '}'){
+					def[def_len] = '\0';
+					txt_len = i - (def_len + 3) - last_normal;
+					if(txt_len > 0){
+						chunks[ch_count].len = txt_len;
+						chunks[ch_count].with = (char*)src+last_normal;
+						ch_count++;
+						result_len += txt_len;
+					}
+					// check whether def is a defined macro.
+					trimmed_len = str_trim(def);
+					char *with = ht_get(ht, def, trimmed_len + 1);
+					// Save the macro expansion chunk, if any.
+					if(with != NULL){
+						with_len = safe_strlen(with);
+						chunks[ch_count].len = with_len;
+						chunks[ch_count].with = with;
+						ch_count++;
+						last_normal = i+1;
+						result_len += with_len;
+					}
+				} else {
+					def[0] = '\0';
+				}
+				def_len = 0;
+				state = NORMAL;
+				break;
+		}
+		i++;
+	}
 
-    // Append a last chunk if last_normal did not reach the end
-    txt_len = src_len - last_normal;
-    if(txt_len > 0){
-        chunks[ch_count].len = txt_len;
-        chunks[ch_count].with = (char*)src+last_normal;
-        ch_count++;
-        result_len += txt_len;
-    }
+	// Append a last chunk if last_normal did not reach the end
+	txt_len = src_len - last_normal;
+	if(txt_len > 0){
+		chunks[ch_count].len = txt_len;
+		chunks[ch_count].with = (char*)src+last_normal;
+		ch_count++;
+		result_len += txt_len;
+	}
 
-    result = malloc(result_len + 1);
+	result = malloc(result_len + 1);
 
-    if(result != NULL){
-        result[0] = '\0';
-        txt_chunk chunk ;
-        for(size_t k = 0; k < ch_count; k++){
-            chunk = chunks[k];
-            strncat(result, chunk.with, chunk.len);
-        }
-        result[result_len] = '\0';
-    }
+	if(result != NULL){
+		result[0] = '\0';
+		txt_chunk chunk ;
+		for(size_t k = 0; k < ch_count; k++){
+			chunk = chunks[k];
+			strncat(result, chunk.with, chunk.len);
+		}
+		result[result_len] = '\0';
+	}
 
-    return result;
+	return result;
 }
 //}}}
 
 // {{{ Insert processed macro in the macros Hash Table.
-void ht_set_processed(const ht_t *ht, const char *key, const char *value) {
-    char *processed = ht_process_macros(ht, value);
-    ht_set(ht, key, safe_strlen(key)+1, processed, safe_strlen(processed)+1);
-    free(processed);
+void ht_set_processed(const ht_t *ht, const char *key, const char *value)
+{
+	char *processed = ht_process_macros(ht, value);
+	ht_set(ht, key, safe_strlen(key)+1, processed, safe_strlen(processed)+1);
+	free(processed);
 }
 // }}}

--- a/src/macros.c
+++ b/src/macros.c
@@ -45,7 +45,7 @@ static FORCE_INLINE uint32_t hash(const void *data, size_t nbytes) {
 
     const int nblocks = nbytes / 4;
     const uint32_t *blocks = (const uint32_t *) (data);
-    const uint8_t *tail = (const uint8_t *) (data + (nblocks * 4));
+    const uint8_t *tail = (const uint8_t *) data + nblocks * 4;
 
     uint32_t h = 0;
 

--- a/src/macros.c
+++ b/src/macros.c
@@ -92,15 +92,15 @@ static FORCE_INLINE uint32_t hash_to_index(const ht_t *ht, uint32_t h) {
 // Trim a string left and right and return its new length
 static FORCE_INLINE size_t str_trim(char *src){
     size_t i = 0;
-    size_t j = safe_strlen(src);
     size_t ts = 0;
-    if(src != NULL){
-        while(i < j && !isgraph(src[i])) i++;
-        while(!isgraph(src[j])) j--;
-        ts = j - i + 1;
-        memcpy(src, src+i, ts);
-        src[ts] = '\0';
-    }
+    size_t j = safe_strlen(src) - 1;
+    if(src == NULL || j <= 0)
+        return 0;
+    while(j > 0 && isspace(src[j])) j--;
+    while(i <= j && isspace(src[i])) i++;
+    ts = j - i + 1;
+    memcpy(src, src+i, ts);
+    src[ts] = '\0';
     return ts;
 }
 

--- a/src/macros.c
+++ b/src/macros.c
@@ -1,0 +1,327 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <stdint.h>
+#include "macros.h"
+
+#define MAX_CHUNKS 32
+#define CHUNK_MAX_LEN 255
+
+#ifdef __GNUC__
+#define FORCE_INLINE __attribute__((always_inline)) inline
+#else
+#define FORCE_INLINE inline
+#endif
+
+#define safe_strlen(x) (((x)==NULL)?0:strlen((x)))
+
+// Text chunks records {{{
+// States of the FSM for transforming a string using a set of macros.
+enum PARSE_STATE {
+    NORMAL,         // before {{macro}} 
+    MACRO,          // inside {{macro}}
+    POST_MACRO,     // after {{macro}}
+};
+
+// Text chunks for text transform.
+typedef struct{
+    int len;
+    char *with;
+} txt_chunk;
+// }}}
+
+// Hash Table for Macros {{{
+// MurMur3 hash function
+static FORCE_INLINE uint32_t hash(const void *data, size_t nbytes) {
+    if (data == NULL || nbytes == 0)
+        return 0;
+
+    const uint32_t c1 = 0xcc9e2d51;
+    const uint32_t c2 = 0x1b873593;
+
+    const int nblocks = nbytes / 4;
+    const uint32_t *blocks = (const uint32_t *) (data);
+    const uint8_t *tail = (const uint8_t *) (data + (nblocks * 4));
+
+    uint32_t h = 0;
+
+    int i;
+    uint32_t k;
+    for (i = 0; i < nblocks; i++) {
+        k = blocks[i];
+
+        k *= c1;
+        k = (k << 15) | (k >> (32 - 15));
+        k *= c2;
+
+        h ^= k;
+        h = (h << 13) | (h >> (32 - 13));
+        h = (h * 5) + 0xe6546b64;
+    }
+
+    k = 0;
+    switch (nbytes & 3) {
+        case 3:
+            k ^= tail[2] << 16;
+        case 2:
+            k ^= tail[1] << 8;
+        case 1:
+            k ^= tail[0];
+            k *= c1;
+            k = (k << 15) | (k >> (32 - 15));
+            k *= c2;
+            h ^= k;
+    };
+
+    h ^= nbytes;
+
+    h ^= h >> 16;
+    h *= 0x85ebca6b;
+    h ^= h >> 13;
+    h *= 0xc2b2ae35;
+    h ^= h >> 16;
+
+    return h;
+}
+
+static FORCE_INLINE uint32_t hash_to_index(const ht_t *ht, uint32_t h) {
+    return h % ht->size;
+}
+
+// Trim a string left and right and return its new length
+static FORCE_INLINE size_t str_trim(char *src){
+    size_t i = 0;
+    size_t j = safe_strlen(src);
+    size_t ts = 0;
+    if(src != NULL){
+        while(i < j && !isgraph(src[i])) i++;
+        while(!isgraph(src[j])) j--;
+        ts = j - i + 1;
+        memcpy(src, src+i, ts);
+        src[ts] = '\0';
+    }
+    return ts;
+}
+
+ht_t *ht_create(const size_t size) {
+    ht_t *ht = malloc(sizeof(ht_t));
+    if(ht == NULL)
+        return ht;
+    ht->size = size;
+    ht->entries = calloc(size, sizeof(macro_t));
+    if(ht->entries == NULL){
+        free(ht);
+        return NULL;
+    }
+    return ht;
+}
+
+void ht_set(const ht_t *ht, const void *key, const size_t k_len, const void *value, const size_t v_len) {
+    uint32_t h = 0;
+    size_t slot = 0;
+    size_t i = 0;
+
+    if(ht == NULL || key == NULL || k_len == 0)
+        return;
+
+    h = hash(key, k_len);
+
+    for (i = 0; i < ht->size; i++){
+        slot = hash_to_index(ht, (h+1));
+        if(ht->entries[slot].key == NULL){
+            ht->entries[slot].key = malloc(k_len);
+            ht->entries[slot].value = malloc(v_len);
+            memcpy(ht->entries[slot].key, key, k_len);
+            memcpy(ht->entries[slot].value, value, v_len);
+            ht->entries[slot].k_len = k_len;
+            ht->entries[slot].v_len = v_len;
+            break;
+        } else if(k_len == ht->entries[slot].k_len){
+            if(memcmp(ht->entries[slot].key, key, k_len) == 0){
+                free(ht->entries[slot].value);
+                ht->entries[slot].value = malloc(v_len);
+                memcpy(ht->entries[slot].value, value, v_len);
+                ht->entries[slot].k_len = k_len;
+                ht->entries[slot].v_len = v_len;
+                break;
+            }
+        }
+    }
+}
+
+void *ht_get(const ht_t *ht, const void *key, const size_t k_len) {
+    uint32_t h = 0;
+    size_t slot = 0;
+
+    if(ht == NULL || key == NULL || k_len == 0)
+        return NULL;
+
+    h = hash(key, k_len);
+
+    for (size_t i = 0; i < ht->size; i++){
+        slot = hash_to_index(ht, (h+1));
+        if(ht->entries[slot].key == NULL){
+            return NULL;
+        } else if(k_len == ht->entries[slot].k_len && memcmp(ht->entries[slot].key, key, k_len) == 0){
+            return ht->entries[slot].value;
+        }
+    }
+    return NULL;
+}
+
+void ht_del(const ht_t *ht, const void *key, const size_t k_len) {
+    uint32_t h = 0;
+    size_t slot = 0;
+
+    if(ht == NULL || key == NULL || k_len == 0)
+        return;
+
+    h = hash(key, k_len);
+
+    for (size_t i = 0; i < ht->size; i++){
+        slot = hash_to_index(ht, (h+1));
+        if(ht->entries[slot].key == NULL){
+            break;
+        } else if(k_len == ht->entries[slot].k_len && memcmp(ht->entries[slot].key, key, k_len) == 0){
+            free(ht->entries[slot].key);
+            free(ht->entries[slot].value);
+            ht->entries[slot].key = NULL;
+            ht->entries[slot].value = NULL;
+            ht->entries[slot].k_len = 0;
+            ht->entries[slot].v_len = 0;
+            break;
+        }
+    }
+}
+
+void ht_destroy(ht_t *ht) {
+
+    if(ht == NULL)
+        return;
+
+    for(size_t i=0; i < ht->size; i++){
+        if(ht->entries[i].key != NULL){
+            free(ht->entries[i].key);
+            free(ht->entries[i].value);
+            ht->entries[i].key = NULL;
+            ht->entries[i].value = NULL;
+        }
+    }
+
+    free(ht->entries);
+    free(ht);
+}
+
+// }}}
+
+// {{{ Macros Processor
+char *ht_process_macros(const ht_t *ht, const char * restrict src){
+    enum PARSE_STATE state = NORMAL;
+    size_t i = 0; 
+    size_t last_normal = 0;
+    size_t txt_len = 0;
+    size_t def_len = 0;
+    size_t result_len = 0;
+    size_t with_len = 0;
+    size_t trimmed_len = 0;
+    size_t ch_count = 0;
+    size_t src_len = safe_strlen(src);
+    txt_chunk chunks[MAX_CHUNKS];
+    char def[CHUNK_MAX_LEN];
+    char *result = NULL;
+
+    if(src_len == 0){
+        // Return an empty string anyways.
+        result = malloc(1);
+        result[0] = '\0';
+        return result;
+    }
+
+    if(ht == NULL){
+        // No ht, return a copy of src.
+        result = malloc(src_len + 1);
+        if(result != NULL){
+            memcpy(result, src, src_len);
+            result[src_len] = '\0';
+        }
+        return result;
+    }
+
+    while(i < src_len){
+        switch (state) {
+            case NORMAL:
+                if(i >= 1 && src[i] == '{' && src[i-1] == '{')
+                    state = MACRO;
+                break;
+            case MACRO:
+                if(src[i] == '}'){
+                    state = POST_MACRO;
+                } else if (src[i] != '{'){
+                    def[def_len++] = src[i];
+                }
+                break;
+            case POST_MACRO:
+                if(src[i] == '}'){
+                    def[def_len] = '\0';
+                    txt_len = i - (def_len + 3) - last_normal;
+                    if(txt_len > 0){
+                        chunks[ch_count].len = txt_len;
+                        chunks[ch_count].with = (char*)src+last_normal;
+                        ch_count++;
+                        result_len += txt_len;
+                    }
+                    // check whether def is a defined macro.
+                    trimmed_len = str_trim(def);
+                    char *with = ht_get(ht, def, trimmed_len + 1);
+                    // Save the macro expansion chunk, if any.
+                    if(with != NULL){
+                        with_len = safe_strlen(with);
+                        chunks[ch_count].len = with_len;
+                        chunks[ch_count].with = with;
+                        ch_count++;
+                        last_normal = i+1;
+                        result_len += with_len;
+                    }
+                } else {
+                    def[0] = '\0';
+                }
+                def_len = 0;
+                state = NORMAL;
+                break;
+        }
+        i++;
+    }
+
+    // Append a last chunk if last_normal did not reach the end
+    txt_len = src_len - last_normal;
+    if(txt_len > 0){
+        chunks[ch_count].len = txt_len;
+        chunks[ch_count].with = (char*)src+last_normal;
+        ch_count++;
+        result_len += txt_len;
+    }
+
+    result = malloc(result_len + 1);
+
+    if(result != NULL){
+        result[0] = '\0';
+        txt_chunk chunk ;
+        for(size_t k = 0; k < ch_count; k++){
+            chunk = chunks[k];
+            strncat(result, chunk.with, chunk.len);
+        }
+        result[result_len] = '\0';
+    }
+
+    return result;
+}
+//}}}
+
+// {{{ Insert processed macro in the macros Hash Table.
+void ht_set_processed(const ht_t *ht, const char *key, const char *value) {
+    char *processed = ht_process_macros(ht, value);
+    ht_set(ht, key, safe_strlen(key)+1, processed, safe_strlen(processed)+1);
+    free(processed);
+}
+// }}}

--- a/src/macros.c
+++ b/src/macros.c
@@ -33,6 +33,9 @@ typedef struct{
 
 // Hash Table for Macros {{{
 // MurMur3 hash function
+// Adapted from:
+// https://github.com/stephane-martin/cycapture/blob/master/cycapture/murmur.c
+// Credit: Stephane Martin
 static FORCE_INLINE uint32_t hash(const void *data, size_t nbytes) {
     if (data == NULL || nbytes == 0)
         return 0;

--- a/src/macros.c
+++ b/src/macros.c
@@ -231,7 +231,7 @@ char *ht_process_macros(const ht_t *ht, const char * restrict src){
     size_t ch_count = 0;
     size_t src_len = safe_strlen(src);
     txt_chunk chunks[MAX_CHUNKS];
-    char def[CHUNK_MAX_LEN];
+    char def[CHUNK_MAX_LEN] = {0};
     char *result = NULL;
 
     if(src_len == 0){

--- a/src/macros.c
+++ b/src/macros.c
@@ -68,8 +68,10 @@ static FORCE_INLINE uint32_t hash(const void *data, size_t nbytes)
 	switch (nbytes & 3) {
 		case 3:
 			k ^= tail[2] << 16;
+			/* FALLTHRU */
 		case 2:
 			k ^= tail[1] << 8;
+			/* FALLTHRU */
 		case 1:
 			k ^= tail[0];
 			k *= c1;

--- a/src/macros.h
+++ b/src/macros.h
@@ -3,16 +3,16 @@
 
 // Macros Hash Table
 typedef struct {
-    void *key;
-    void *value;
-    size_t k_len;
-    size_t v_len;
+	void *key;
+	void *value;
+	size_t k_len;
+	size_t v_len;
 } macro_t;
 
 // A Hash Table is a dynamically allocated array of macros.
 typedef struct{
-    macro_t *entries;
-    size_t size;
+	macro_t *entries;
+	size_t size;
 } ht_t;
 
 ht_t *ht_create(const size_t size);

--- a/src/macros.h
+++ b/src/macros.h
@@ -1,0 +1,26 @@
+#ifndef MACROS_H
+#define MACROS_H
+
+// Macros Hash Table
+typedef struct {
+    void *key;
+    void *value;
+    size_t k_len;
+    size_t v_len;
+} macro_t;
+
+// A Hash Table is a dynamically allocated array of macros.
+typedef struct{
+    macro_t *entries;
+    size_t size;
+} ht_t;
+
+ht_t *ht_create(const size_t size);
+void ht_set(const ht_t *ht, const void *key, const size_t k_len, const void *value, const size_t v_len);
+void *ht_get(const ht_t *ht, const void *key, const size_t k_len);
+void ht_del(const ht_t *ht, const void *key, const size_t k_len);
+void ht_destroy(ht_t *ht);
+char *ht_process_macros(const ht_t *ht, const char *src);
+void ht_set_processed(const ht_t *ht, const char *key, const char *value);
+
+#endif /* ifndef MACROS_H */

--- a/src/parse.c
+++ b/src/parse.c
@@ -2681,7 +2681,7 @@ chunk_t *extract_chunks(char *s)
 
 chunk_t *make_chunk(void)
 {
-	chunk_t *c = malloc(sizeof(chunk_t));
+	chunk_t *c = calloc(1, sizeof(chunk_t));
 	c->sequence = false;
 	c->advance = NULL;
 	c->next = NULL;

--- a/src/parse.c
+++ b/src/parse.c
@@ -2372,28 +2372,29 @@ keysym_dict_t nks_dict[] = {/*{{{*/
 #define HASH_TABLE_SIZE 1543
 
 #define IS_DEF(x) (\
-    (x[0] == 'D' || x[0] == 'd') && \
-    (x[1] == 'E' || x[1] == 'e') && \
-    (x[2] == 'F' || x[2] == 'f') && \
-    (x[3] == ' ' || x[3] == '\t'))
+	(x[0] == 'D' || x[0] == 'd') && \
+	(x[1] == 'E' || x[1] == 'e') && \
+	(x[2] == 'F' || x[2] == 'f') && \
+	(x[3] == ' ' || x[3] == '\t'))
 
-static inline void parse_macro(ht_t *ht, const char *macro_string, char *prefix){
-    char name[MAXLEN];
-    char value[MAXLEN];
-    size_t i = strlen(prefix) + 1; // strlen("DEF") + 1
-    size_t ni = 0; // name index
-    size_t vi = 0; // value index
-    name[0] = value[0] = '\0';
-    while(isspace(macro_string[i])) i++;
-    while(isgraph(macro_string[i]))
-       name[ni++] = macro_string[i++];
-    while(isspace(macro_string[i])) i++;
-    while(macro_string[i] != '\0')
-       value[vi++] = macro_string[i++];
-    name[ni] = '\0';
-    value[vi] = '\0';
-    PRINTF("> MACRO: '%s' -> '%s'\n", name, value);
-    ht_set_processed(ht, name, value);
+static inline void parse_macro(ht_t *ht, const char *macro_string, char *prefix)
+{
+	char name[MAXLEN];
+	char value[MAXLEN];
+	size_t i = strlen(prefix) + 1; // strlen("DEF") + 1
+	size_t ni = 0; // name index
+	size_t vi = 0; // value index
+	name[0] = value[0] = '\0';
+	while(isspace(macro_string[i])) i++;
+	while(isgraph(macro_string[i]))
+	   name[ni++] = macro_string[i++];
+	while(isspace(macro_string[i])) i++;
+	while(macro_string[i] != '\0')
+	   value[vi++] = macro_string[i++];
+	name[ni] = '\0';
+	value[vi] = '\0';
+	PRINTF("> MACRO: '%s' -> '%s'\n", name, value);
+	ht_set_processed(ht, name, value);
 }
 
 void load_config(const char *config_file)
@@ -2409,11 +2410,11 @@ void load_config(const char *config_file)
 	char command[2 * MAXLEN] = {0};
 	int offset = 0;
 	char first;
-    char *var_chain = NULL;
-    char *var_command = NULL;
-    bool macro_state = false;
+	char *var_chain = NULL;
+	char *var_command = NULL;
+	bool macro_state = false;
 
-    ht_t *ht = ht_create(HASH_TABLE_SIZE);
+	ht_t *ht = ht_create(HASH_TABLE_SIZE);
 
 	while (fgets(buf, sizeof(buf), cfg) != NULL) {
 		first = buf[0];
@@ -2426,12 +2427,12 @@ void load_config(const char *config_file)
 			char *end = rgraph(buf);
 			*(end + 1) = '\0';
 
-            macro_state = IS_DEF(start) || macro_state;
+			macro_state = IS_DEF(start) || macro_state;
 			if (isgraph(first) || macro_state)
-                if (macro_state)
-                    snprintf(macro + offset, sizeof(macro) - offset, "%s", start);
-                else
-                    snprintf(chain + offset, sizeof(chain) - offset, "%s", start);
+				if (macro_state)
+					snprintf(macro + offset, sizeof(macro) - offset, "%s", start);
+				else
+					snprintf(chain + offset, sizeof(chain) - offset, "%s", start);
 			else
 				snprintf(command + offset, sizeof(command) - offset, "%s", start);
 
@@ -2440,29 +2441,28 @@ void load_config(const char *config_file)
 				continue;
 			} else {
 				offset = 0;
-                macro_state = false;
+				macro_state = false;
 			}
 
-            if(strlen(macro) > 0){
-                parse_macro(ht, macro, "DEF");
-                macro[0] = '\0';
-                continue;
-            }
+			if(strlen(macro) > 0){
+				parse_macro(ht, macro, "DEF");
+				macro[0] = '\0';
+				continue;
+			}
 
 			if (isspace(first) && strlen(chain) > 0 && strlen(command) > 0) {
-                var_chain = ht_process_macros(ht, chain);
-                var_command = ht_process_macros(ht, command);
-                process_hotkey(var_chain, var_command);
-                free(var_chain);
-                free(var_command);
-                chain[0] = '\0';
-                command[0] = '\0';
+				var_chain = ht_process_macros(ht, chain);
+				var_command = ht_process_macros(ht, command);
+				process_hotkey(var_chain, var_command);
+				free(var_chain);
+				free(var_command);
+				chain[0] = '\0';
+				command[0] = '\0';
 			}
 		}
 	}
 
-
-    ht_destroy(ht);
+	ht_destroy(ht);
 	fclose(cfg);
 }
 


### PR DESCRIPTION
First of all, I'd like to thank @baskerville and all the contributors to this project. It is simple yet very powerful!

I've seen in the past some asking how to define global variables (#129), and I have to admit, I also wanted a way to define a variable once and then use it several times in the configuration file. 

I thus decided to implement a "macros" feature for sxhkd using a hash table and an efficient text replacement algorithm. I'm using this feature since two months ago, and I hope you'll like it too. Below is what I've added in the README file as an explanation of this feature.

The configuration file _may_ contain a set of macros to ease bindings definitions. A macro is defined using the keyword `DEF` as follows:

    # A general prefix key for launching applications
    DEF APP_KEY super + x

    # Rofi shortned.
    DEF ROFI rofi -matching fuzzy -modi 'window,windowcd,run,drun'
    DEF MAKE_TIMESTAMP  $(date +%Y-%m-%d_%H%M%S)

    # Icons
    DEF ICONS_PATH /usr/share/icons/Papirus-Dark/48x48
    DEF SCROT_ICON {{ICONS_PATH}}/apps/screengrab.svg

In the examples above, `ROFI` is a macro, and its replacement text is `rofi -matching fuzzy -modi 'window,windowcd,run,drun'`. Now, we can use `{{ROFI}}` anywhere in the configuration file and it will be replaced with the replacement text. 

Note also how we have defined a common icons path using the macro `ICONS_PATH` and how we have used it to define `SCROT_ICON`. In fact, macros may be defined using previously defined macros, and so on.

Using these macros, we can define a binding to take screen shots (using scrot) as follows:

    {{APP_KEY}} ; p
        stamp={{MAKE_TIMESTAMP}};\
        filename="/tmp/screen_$stamp.png";\
        scrot $filename;\
        notify-send -a 'Scrot' "Screenshot taken in $filename" -i {{SCROT_ICON}};

Macros may essentially be used for modularity (See the icons macros above), to avoid typing (eg. ROFI), and to define global variables.