### PR TITLE
Add warning about interfering hotkeys

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -2470,6 +2470,11 @@ void process_hotkey(char *hotkey_string, char *command_string)
 		chain_t *chain = make_chain();
 		if (parse_chain(hotkey, chain)) {
 			hotkey_t *hk = make_hotkey(chain, command);
+			for (hotkey_t* i = hotkeys_head; i; i = i->next) {
+				if (chains_interfere(i->chain, hk->chain)) {
+					warn("hotkey interference found and may not be matched: '%s' (from '%s')\n", hotkey, hotkey_string);
+				}
+			}
 			add_hotkey(hk);
 			if (strcmp(hotkey, last_hotkey) == 0)
 				num_same++;

--- a/src/types.c
+++ b/src/types.c
@@ -118,8 +118,8 @@ bool chains_interfere(chain_t* a, chain_t* b) {
 	chord_t* j = b->head;
 	for (; i && j; i = i->next, j = j->next) {
 		bool match = false;
-		for (chord_t* u = i, *v = j; u && v; u = u->more, v = v->more) {
-			if (u->event_type == v->event_type && u->keysym == v->keysym && u->button == v->button && u->modfield == v->modfield) {
+		for (chord_t* k = i; k; k = k->more) {
+			if (match_chord(j, k->event_type, k->keysym, k->button, k->modfield)) {
 				match = true;
 				break;
 			}

--- a/src/types.c
+++ b/src/types.c
@@ -113,6 +113,25 @@ bool match_chord(chord_t *chord, uint8_t event_type, xcb_keysym_t keysym, xcb_bu
 	return false;
 }
 
+bool chains_interfere(chain_t* a, chain_t* b) {
+	chord_t* i = a->head;
+	chord_t* j = b->head;
+	for (; i && j; i = i->next, j = j->next) {
+		bool match = false;
+		for (chord_t* u = i, *v = j; u && v; u = u->more, v = v->more) {
+			if (u->event_type == v->event_type && u->keysym == v->keysym && u->button == v->button && u->modfield == v->modfield) {
+				match = true;
+				break;
+			}
+		}
+		if (!match) {
+			break;
+		}
+	}
+	bool result = !i || !j;
+	return result;
+}
+
 chord_t *make_chord(xcb_keysym_t keysym, xcb_button_t button, uint16_t modfield, uint8_t event_type, bool replay_event, bool lock_chain)
 {
 	chord_t *chord;

--- a/src/types.h
+++ b/src/types.h
@@ -77,6 +77,7 @@ typedef struct {
 
 hotkey_t *find_hotkey(xcb_keysym_t keysym, xcb_button_t button, uint16_t modfield, uint8_t event_type, bool *replay_event);
 bool match_chord(chord_t *chord, uint8_t event_type, xcb_keysym_t keysym, xcb_button_t button, uint16_t modfield);
+bool chains_interfere(chain_t* a, chain_t* b);
 chord_t *make_chord(xcb_keysym_t keysym, xcb_button_t button, uint16_t modfield, uint8_t event_type, bool replay_event, bool lock_chain);
 void add_chord(chain_t *chain, chord_t *chord);
 chain_t *make_chain(void);


### PR DESCRIPTION
Adds a warning that single-chord hotkeys are the same or that one chord chain is a prefix of another.  Fixes #201.