### PR TITLE
Add option to print hotkeys' descriptions to stdout

### DIFF
--- a/doc/sxhkd.1
+++ b/doc/sxhkd.1
@@ -2,12 +2,12 @@
 .\"     Title: sxhkd
 .\"    Author: [see the "Author" section]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 08/02/2020
+.\"      Date: 09/03/2021
 .\"    Manual: Sxhkd Manual
 .\"    Source: Sxhkd 0.6.2
 .\"  Language: English
 .\"
-.TH "SXHKD" "1" "08/02/2020" "Sxhkd 0\&.6\&.2" "Sxhkd Manual"
+.TH "SXHKD" "1" "09/03/2021" "Sxhkd 0\&.6\&.2" "Sxhkd Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -77,6 +77,11 @@ Output status information to the given FIFO\&.
 \fB\-a\fR \fIABORT_KEYSYM\fR
 .RS 4
 Name of the keysym used for aborting chord chains\&.
+.RE
+.PP
+\fB\-p\fR
+.RS 4
+Print hotkeys and associated commands read from config files to stdout\&.
 .RE
 .SH "BEHAVIOR"
 .sp

--- a/doc/sxhkd.1.asciidoc
+++ b/doc/sxhkd.1.asciidoc
@@ -48,6 +48,9 @@ Options
 *-a* _ABORT_KEYSYM_::
     Name of the keysym used for aborting chord chains.
 
+*-p*::
+    Print hotkeys and associated commands read from config files to stdout.
+
 
 Behavior
 --------

--- a/src/parse.c
+++ b/src/parse.c
@@ -2687,7 +2687,7 @@ bool parse_chain(char *string, chain_t *chain)
 			return false;
 		}
 		add_chord(chain, c);
-		if (status_fifo != NULL) {
+		if (status_fifo != NULL || print_hotkeys_mode) {
 			snprintf(c->repr, sizeof(c->repr), "%s", chord);
 		}
 		keysym = XCB_NO_SYMBOL;

--- a/src/sxhkd.h
+++ b/src/sxhkd.h
@@ -58,7 +58,7 @@ extern int mapping_count;
 extern int timeout;
 
 extern hotkey_t *hotkeys_head, *hotkeys_tail;
-extern bool running, grabbed, toggle_grab, reload, bell, chained, locked;
+extern bool running, grabbed, toggle_grab, reload, bell, chained, locked, print_hotkeys_mode;
 extern xcb_keysym_t abort_keysym;
 extern chord_t *abort_chord;
 
@@ -74,5 +74,7 @@ void reload_cmd(void);
 void toggle_grab_cmd(void);
 void hold(int sig);
 void put_status(char c, const char *s);
+void print_chord(chord_t *chord);
+void print_hotkeys(hotkey_t *head, hotkey_t *tail);
 
 #endif


### PR DESCRIPTION
The option -p now makes sxhkd read its configuration files, print
the hotkeys that were read to stdout, and exit with status 0.