### PR TITLE
Better support for multiple keyboard layouts.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VERSION := $(shell $(VERCMD) || cat VERSION)
 CPPFLAGS += -D_POSIX_C_SOURCE=200112L -DVERSION=\"$(VERSION)\"
 CFLAGS   += -std=c99 -pedantic -Wall -Wextra
 LDFLAGS  ?=
-LDLIBS    = $(LDFLAGS) -lxcb -lxcb-keysyms
+LDLIBS    = $(LDFLAGS) -lxcb -lxcb-keysyms -lxcb-xkb -lxkbcommon -lxkbcommon-x11
 
 PREFIX    ?= /usr/local
 BINPREFIX ?= $(PREFIX)/bin

--- a/Sourcedeps
+++ b/Sourcedeps
@@ -1,10 +1,12 @@
-grab.o: grab.c grab.h helpers.h parse.h sxhkd.h types.h
+keys.o: keys.c keys.h
+OBJ += keys.o
+grab.o: grab.c grab.h helpers.h parse.h sxhkd.h types.h keys.c keys.h
 OBJ += grab.o
 helpers.o: helpers.c helpers.h sxhkd.h types.h
 OBJ += helpers.o
-parse.o: parse.c helpers.h locales.h parse.h sxhkd.h types.h
+parse.o: parse.c helpers.h locales.h parse.h sxhkd.h types.h keys.c keys.h
 OBJ += parse.o
 sxhkd.o: sxhkd.c grab.h helpers.h parse.h sxhkd.h types.h
 OBJ += sxhkd.o
-types.o: types.c grab.h helpers.h parse.h sxhkd.h types.h
+types.o: types.c grab.h helpers.h parse.h sxhkd.h types.h keys.c keys.h
 OBJ += types.o

--- a/src/keys.c
+++ b/src/keys.c
@@ -1,0 +1,95 @@
+#include "keys.h"
+#include <stdlib.h>
+#include <stddef.h>
+
+struct keysym_array keycode_to_keysyms(struct xkb_keymap* keymap, xkb_keycode_t keycode)
+{
+	xkb_keysym_t const* data  = NULL;
+	int                 count = 0;
+	count = xkb_keymap_key_get_syms_by_level(keymap, keycode, 0, 0, &data);
+
+	if(count <= 0) {
+		return (struct keysym_array){ .data = NULL, .count = 0 };
+	}
+
+	return (struct keysym_array){ .data = data, .count = count };
+}
+
+xkb_keysym_t keycode_to_keysym (struct xkb_keymap* keymap, xkb_keycode_t keycode)
+{
+	struct keysym_array keysyms = keycode_to_keysyms(keymap, keycode);
+
+	if(keysyms.data)
+		return *keysyms.data;
+	else 
+		return XKB_KEY_NoSymbol;
+}
+
+void keycode_array_free(struct keycode_array* keycodes)
+{
+	if(keycodes->data) {
+		free(keycodes->data);
+		keycodes->data  = NULL;
+		keycodes->count = 0;
+	}
+}
+
+struct keycodes_from_keysym_iterator
+{
+	xkb_keysym_t    keysym;
+	xkb_keycode_t * data;
+	size_t          count;
+};
+
+static void keycodes_from_keysym_counter(struct xkb_keymap* keymap, xkb_keycode_t keycode, void* data)
+{
+	struct keycodes_from_keysym_iterator * state = data;
+	struct keysym_array keysyms = keycode_to_keysyms(keymap, keycode);
+
+	xkb_keysym_t const* first = keysyms.data;
+	xkb_keysym_t const* last  = keysyms.data + keysyms.count;
+
+	for(; first != last; ++first) {
+		if(state->keysym == *first) {
+			state->count++;
+			break;
+		}
+	}
+}
+
+static void keycodes_from_keysym_collector(struct xkb_keymap* keymap, xkb_keycode_t keycode, void* data)
+{
+	struct keycodes_from_keysym_iterator * state   = data;
+	struct keysym_array                    keysyms = keycode_to_keysyms(keymap, keycode);
+
+	xkb_keysym_t const* first = keysyms.data;
+	xkb_keysym_t const* last  = keysyms.data + keysyms.count;
+
+	for(; first != last; ++first) {
+		if(state->keysym == *first) {
+			state->data[state->count++] = keycode;
+			break;
+		}
+	}
+}
+
+struct keycode_array keycodes_from_keysym(struct xkb_keymap* keymap, xkb_keysym_t keysym)
+{
+	struct keycodes_from_keysym_iterator counter = {
+		.keysym = keysym,
+		.data   = NULL,
+		.count  = 0
+	};
+
+	xkb_keymap_key_for_each(keymap, keycodes_from_keysym_counter, &counter);
+
+	struct keycodes_from_keysym_iterator collector = {
+		.keysym = keysym,
+		.data   = malloc(counter.count * sizeof(xkb_keycode_t)),
+		.count  = 0
+	};
+
+	xkb_keymap_key_for_each(keymap, keycodes_from_keysym_collector, &collector);
+
+	return (struct keycode_array){ .data = collector.data, .count = collector.count };
+}

--- a/src/keys.h
+++ b/src/keys.h
@@ -1,0 +1,24 @@
+#ifndef SXHKD_KEYS_H
+#define SXHKD_KEYS_H
+
+#include <xkbcommon/xkbcommon.h>
+
+struct keysym_array {
+	xkb_keysym_t const* data;
+	size_t              count;
+};
+
+struct keycode_array {
+	xkb_keycode_t * data;
+	size_t          count;
+};
+
+void keycode_array_free(struct keycode_array*);
+
+struct keysym_array keycode_to_keysyms(struct xkb_keymap*, xkb_keycode_t);
+xkb_keysym_t        keycode_to_keysym (struct xkb_keymap*, xkb_keycode_t);
+
+struct keycode_array keycodes_from_keysym(struct xkb_keymap*, xkb_keysym_t);
+
+#endif
+

--- a/src/parse.c
+++ b/src/parse.c
@@ -31,6 +31,7 @@
 #include <ctype.h>
 #include "locales.h"
 #include "parse.h"
+#include "keys.h"
 
 xcb_keysym_t Alt_L, Alt_R, Super_L, Super_R, Hyper_L, Hyper_R,
              Meta_L, Meta_R, Mode_switch, Num_Lock, Scroll_Lock;
@@ -2421,13 +2422,13 @@ void parse_event(xcb_generic_event_t *evt, uint8_t event_type, xcb_keysym_t *key
 		xcb_key_press_event_t *e = (xcb_key_press_event_t *) evt;
 		xcb_keycode_t keycode = e->detail;
 		*modfield = e->state;
-		*keysym = xcb_key_symbols_get_keysym(symbols, keycode, 0);
+		*keysym = keycode_to_keysym(kb_keymap, keycode);
 		PRINTF("key press %u %u\n", keycode, *modfield);
 	} else if (event_type == XCB_KEY_RELEASE) {
 		xcb_key_release_event_t *e = (xcb_key_release_event_t *) evt;
 		xcb_keycode_t keycode = e->detail;
 		*modfield = e->state & ~modfield_from_keycode(keycode);
-		*keysym = xcb_key_symbols_get_keysym(symbols, keycode, 0);
+		*keysym = keycode_to_keysym(kb_keymap, keycode);
 		PRINTF("key release %u %u\n", keycode, *modfield);
 	} else if (event_type == XCB_BUTTON_PRESS) {
 		xcb_button_press_event_t *e = (xcb_button_press_event_t *) evt;
@@ -2814,12 +2815,12 @@ void get_lock_fields(void)
 int16_t modfield_from_keysym(xcb_keysym_t keysym)
 {
 	uint16_t modfield = 0;
-	xcb_keycode_t *keycodes = NULL;
-	if ((keycodes = keycodes_from_keysym(keysym)) != NULL) {
-		for (xcb_keycode_t *k = keycodes; *k != XCB_NO_SYMBOL; k++)
-			modfield |= modfield_from_keycode(*k);
+	struct keycode_array keycodes = keycodes_from_keysym(kb_keymap, keysym);
+	if (keycodes.data != NULL) {
+		for (xkb_keycode_t const* kc = keycodes.data; kc != keycodes.data + keycodes.count; ++kc)
+			modfield |= modfield_from_keycode(*kc);
 	}
-	free(keycodes);
+	keycode_array_free(&keycodes);
 	return modfield;
 }
 
@@ -2845,37 +2846,4 @@ int16_t modfield_from_keycode(xcb_keycode_t keycode)
 	}
 	free(reply);
 	return modfield;
-}
-
-xcb_keycode_t *keycodes_from_keysym(xcb_keysym_t keysym)
-{
-	xcb_setup_t const *setup;
-	unsigned int num = 0;
-	xcb_keycode_t *result = NULL, *result_np = NULL;
-
-	if ((setup = xcb_get_setup(dpy)) != NULL) {
-		xcb_keycode_t min_kc = setup->min_keycode;
-		xcb_keycode_t max_kc = setup->max_keycode;
-
-		/* We must choose a type for kc other than xcb_keycode_t whose size
-		 * is 1, otherwise, since max_kc will most likely be 255, if kc == 255,
-		 * kc++ would be 0 and the outer loop would start over ad infinitum */
-		for(unsigned int kc = min_kc; kc <= max_kc; kc++)
-			for(unsigned int col = 0; col < KEYSYMS_PER_KEYCODE; col++) {
-				xcb_keysym_t ks = xcb_key_symbols_get_keysym(symbols, kc, col);
-				if (ks == keysym) {
-					num++;
-					result_np = realloc(result, sizeof(xcb_keycode_t) * (num + 1));
-					if (result_np == NULL) {
-						free(result);
-						return NULL;
-					}
-					result = result_np;
-					result[num - 1] = kc;
-					result[num] = XCB_NO_SYMBOL;
-					break;
-				}
-			}
-	}
-	return result;
 }

--- a/src/parse.h
+++ b/src/parse.h
@@ -69,6 +69,5 @@ void get_standard_keysyms(void);
 void get_lock_fields(void);
 int16_t modfield_from_keysym(xcb_keysym_t keysym);
 int16_t modfield_from_keycode(xcb_keycode_t keycode);
-xcb_keycode_t *keycodes_from_keysym(xcb_keysym_t keysym);
 
 #endif

--- a/src/sxhkd.c
+++ b/src/sxhkd.c
@@ -38,7 +38,9 @@
 
 xcb_connection_t *dpy;
 xcb_window_t root;
-xcb_key_symbols_t *symbols;
+int32_t             kb_device  = -1;
+struct xkb_context* kb_context = NULL;
+struct xkb_keymap*  kb_keymap  = NULL;
 
 char *shell;
 char config_file[MAXLEN];
@@ -217,7 +219,8 @@ int main(int argc, char *argv[])
 	ungrab();
 	cleanup();
 	destroy_chord(abort_chord);
-	xcb_key_symbols_free(symbols);
+	xkb_keymap_unref(kb_keymap);
+	xkb_context_unref(kb_context);
 	xcb_disconnect(dpy);
 	return EXIT_SUCCESS;
 }
@@ -257,6 +260,23 @@ void key_button_event(xcb_generic_event_t *evt, uint8_t event_type)
 	xcb_flush(dpy);
 }
 
+static bool refresh_keymap(void)
+{
+	struct xkb_keymap* keymap
+		= xkb_x11_keymap_new_from_device( kb_context
+		                                , dpy
+		                                , kb_device
+		                                , XKB_KEYMAP_COMPILE_NO_FLAGS);
+
+	if(keymap == NULL)
+		return false;
+
+	xkb_keymap_unref(kb_keymap);
+	kb_keymap = keymap;
+
+	return true;
+}
+
 void mapping_notify(xcb_generic_event_t *evt)
 {
 	if (!mapping_count)
@@ -265,7 +285,8 @@ void mapping_notify(xcb_generic_event_t *evt)
 	PRINTF("mapping notify %u %u\n", e->request, e->count);
 	if (e->request == XCB_MAPPING_POINTER)
 		return;
-	if (xcb_refresh_keyboard_mapping(symbols, e) == 1) {
+
+	if (refresh_keymap()) {
 		destroy_chord(abort_chord);
 		get_lock_fields();
 		reload_cmd();
@@ -294,7 +315,17 @@ void setup(void)
 	root = screen->root;
 	if ((shell = getenv(SXHKD_SHELL_ENV)) == NULL && (shell = getenv(SHELL_ENV)) == NULL)
 		err("The '%s' environment variable is not defined.\n", SHELL_ENV);
-	symbols = xcb_key_symbols_alloc(dpy);
+
+	// TODO:
+	// - Allow specifying keymap on the command line.
+	xcb_xkb_use_extension(dpy, XCB_XKB_MAJOR_VERSION, XCB_XKB_MINOR_VERSION);
+	if(NULL == (kb_context = xkb_context_new(XKB_CONTEXT_NO_FLAGS)))
+		err("Failed to allocate xkb context.\n");
+	if(-1 == (kb_device  = xkb_x11_get_core_keyboard_device_id(dpy)))
+		err("Failed to retrieve keyboard device.\n");
+	if(! refresh_keymap())
+		err("Failed to retrieve keymap.\n");
+
 	hotkeys_head = hotkeys_tail = NULL;
 	progress[0] = '\0';
 }

--- a/src/sxhkd.h
+++ b/src/sxhkd.h
@@ -26,6 +26,9 @@
 #define SXHKD_SXHKD_H
 
 #include <xcb/xcb_keysyms.h>
+#include <xcb/xkb.h>
+#include <xkbcommon/xkbcommon.h>
+#include <xkbcommon/xkbcommon-x11.h>
 #include <stdio.h>
 #include <stdbool.h>
 #include "types.h"
@@ -44,7 +47,9 @@
 
 extern xcb_connection_t *dpy;
 extern xcb_window_t root;
-extern xcb_key_symbols_t *symbols;
+extern int32_t kb_device;
+extern struct xkb_context* kb_context;
+extern struct xkb_keymap*  kb_keymap;
 
 extern char *shell;
 extern char config_file[MAXLEN];

--- a/src/types.c
+++ b/src/types.c
@@ -29,6 +29,7 @@
 #include <unistd.h>
 #include "parse.h"
 #include "grab.h"
+#include "keys.h"
 
 hotkey_t *find_hotkey(xcb_keysym_t keysym, xcb_button_t button, uint16_t modfield, uint8_t event_type, bool *replay_event)
 {
@@ -115,18 +116,24 @@ bool match_chord(chord_t *chord, uint8_t event_type, xcb_keysym_t keysym, xcb_bu
 
 chord_t *make_chord(xcb_keysym_t keysym, xcb_button_t button, uint16_t modfield, uint8_t event_type, bool replay_event, bool lock_chain)
 {
-	chord_t *chord;
+	chord_t *chord = NULL;
 	if (button == XCB_NONE) {
 		chord_t *prev = NULL;
 		chord_t *orig = NULL;
-		xcb_keycode_t *keycodes = keycodes_from_keysym(keysym);
-		if (keycodes != NULL) {
-			for (xcb_keycode_t *kc = keycodes; *kc != XCB_NO_SYMBOL; kc++) {
-				xcb_keysym_t natural_keysym = xcb_key_symbols_get_keysym(symbols, *kc, 0);
-				for (unsigned char col = 0; col < KEYSYMS_PER_KEYCODE; col++) {
-					xcb_keysym_t ks = xcb_key_symbols_get_keysym(symbols, *kc, col);
-					if (ks == keysym) {
-						uint16_t implicit_modfield = (col & 1 ? XCB_MOD_MASK_SHIFT : 0) | (col & 2 ? modfield_from_keysym(Mode_switch) : 0);
+		// TODO:
+		// - again turning keysym into keycodes and back
+		// - why?
+		struct keycode_array keycodes = keycodes_from_keysym(kb_keymap, keysym);
+		if (keycodes.data != NULL) {
+			for (xkb_keycode_t const* kc = keycodes.data; kc != keycodes.data + keycodes.count; ++kc) {
+				xcb_keysym_t natural_keysym = keycode_to_keysym(kb_keymap, *kc);
+				struct keysym_array keysyms = keycode_to_keysyms(kb_keymap, *kc);
+				for (xkb_keysym_t const* ks = keysyms.data; ks != keysyms.data + keysyms.count; ++ks) {
+					if (*ks == keysym) {
+						// TODO:
+						// - this seems to consider modified versions of a keysym, i.e. a -> {a, A}
+						//uint16_t implicit_modfield = (col & 1 ? XCB_MOD_MASK_SHIFT : 0) | (col & 2 ? modfield_from_keysym(Mode_switch) : 0);
+						uint16_t implicit_modfield = 0;
 						uint16_t explicit_modfield = modfield | implicit_modfield;
 						chord = malloc(sizeof(chord_t));
 						bool unique = true;
@@ -157,7 +164,7 @@ chord_t *make_chord(xcb_keysym_t keysym, xcb_button_t button, uint16_t modfield,
 		} else {
 			warn("No keycodes found for keysym %u.\n", keysym);
 		}
-		free(keycodes);
+		keycode_array_free(&keycodes);
 		chord = orig;
 	} else {
 		chord = malloc(sizeof(chord_t));
@@ -251,6 +258,8 @@ void destroy_chain(chain_t *chain)
 
 void destroy_chord(chord_t *chord)
 {
+	if(chord == NULL)
+		return;
 	chord_t *c = chord->more;
 	while (c != NULL) {
 		chord_t *n = c->more;


### PR DESCRIPTION
_Disclaimer_: I am opening this pull request to get some early feedback on my changes. I am actually still on xbindkeys at the moment, so I have not even fully tested them (`ctrl + u: echo hello word` works, though). There are some todos I would like your input on.

### How I want to handle multiple layouts
- specify a base layout up front (command line / maybe config file)
- resolve key codes with respect to this layout regardless of the one being active

### How this is different from the status quo
- as I understand it, sxhkd currently locks in on the layout that is active at startup (or responds mapping events)
- I never actually use the layout I want as my base (base: qwertz, active: dvorak,cyrillic,...)
- current mapping can be broken by restarting sxhkd while the wrong initial layout is active
### Status
- [x] Use XKB to select the keymap and handle keycode <-> keysym conversions
- [ ] Treat `ctrl + U` as `ctrl + shift + u` (is there a point to it anyway?)
- [ ] Figure out the point of the keysym -> keycodes -> keysyms conversion sequence (does this relate to the above point?)
- [ ] Add the command line flags (--rule,--model,--layout,--variant,--options)