### PR TITLE
Add SXHKD_PID environment variable

### DIFF
--- a/doc/sxhkd.1
+++ b/doc/sxhkd.1
@@ -2,12 +2,12 @@
 .\"     Title: sxhkd
 .\"    Author: [see the "Author" section]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 08/02/2020
+.\"      Date: 08/26/2022
 .\"    Manual: Sxhkd Manual
-.\"    Source: Sxhkd 0.6.2
+.\"    Source: Sxhkd 0.6.2-1-ga232f60
 .\"  Language: English
 .\"
-.TH "SXHKD" "1" "08/02/2020" "Sxhkd 0\&.6\&.2" "Sxhkd Manual"
+.TH "SXHKD" "1" "08/26/2022" "Sxhkd 0\&.6\&.2\-1\-ga232f60" "Sxhkd Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -88,9 +88,13 @@ Additional configuration files can be passed as arguments\&.
 .sp
 If \fBsxhkd\fR receives a \fISIGUSR1\fR (resp\&. \fISIGUSR2\fR) signal, it will reload its configuration file (resp\&. toggle the grabbing state of all its bindings)\&.
 .sp
+If \fBsxhkd\fR recieves a \fISIGALRM\fR signal, it will break the current chain if there is one in progress\&.
+.sp
 The commands are executed via \fBSHELL\fR \fI\-c\fR \fBCOMMAND\fR (hence you can use environment variables)\&.
 .sp
 \fBSHELL\fR will be the content of the first defined environment variable in the following list: \fBSXHKD_SHELL\fR, \fBSHELL\fR\&.
+.sp
+\fBSXHKD_PID\fR will be automatically set to the pid of \fBsxhkd\fR in processes spawned by \fBsxhkd\fR, which may be used by the child process to send easily signals such as \fISIGALRM\fR to the correct instance of \fBsxhkd\fR\&.
 .sp
 If you have a non\-QWERTY keyboard or a non\-standard layout configuration, you should provide a \fICOUNT\fR of \fI1\fR to the \fB\-m\fR option or \fI\-1\fR (interpreted as infinity) if you constantly switch from one layout to the other (\fBsxhkd\fR ignores all mapping notify events by default because the majority of those events are pointless)\&.
 .SH "CONFIGURATION"

--- a/doc/sxhkd.1.asciidoc
+++ b/doc/sxhkd.1.asciidoc
@@ -60,9 +60,13 @@ Additional configuration files can be passed as arguments.
 
 If *sxhkd* receives a _SIGUSR1_ (resp. _SIGUSR2_) signal, it will reload its configuration file (resp. toggle the grabbing state of all its bindings).
 
+If *sxhkd* recieves a _SIGALRM_ signal, it will break the current chain if there is one in progress.
+
 The commands are executed via *SHELL* _-c_ *COMMAND* (hence you can use environment variables).
 
 *SHELL* will be the content of the first defined environment variable in the following list: *SXHKD_SHELL*, *SHELL*.
+
+*SXHKD_PID* will be automatically set to the pid of *sxhkd* in processes spawned by *sxhkd*, which may be used by the child process to send easily signals such as _SIGALRM_ to the correct instance of *sxhkd*.
 
 If you have a non-QWERTY keyboard or a non-standard layout configuration, you should provide a _COUNT_ of _1_ to the *-m* option or _-1_ (interpreted as infinity) if you constantly switch from one layout to the other (*sxhkd* ignores all mapping notify events by default because the majority of those events are pointless).
 

--- a/src/sxhkd.c
+++ b/src/sxhkd.c
@@ -51,6 +51,8 @@ char progress[3 * MAXLEN];
 int mapping_count;
 int timeout;
 
+char sxhkd_pid[MAXLEN];
+
 hotkey_t *hotkeys_head, *hotkeys_tail;
 bool running, grabbed, toggle_grab, reload, bell, chained, locked;
 xcb_keysym_t abort_keysym;
@@ -297,6 +299,9 @@ void setup(void)
 	symbols = xcb_key_symbols_alloc(dpy);
 	hotkeys_head = hotkeys_tail = NULL;
 	progress[0] = '\0';
+
+	snprintf(sxhkd_pid, MAXLEN, "%i", getpid());
+	setenv("SXHKD_PID", sxhkd_pid, 1);
 }
 
 void cleanup(void)


### PR DESCRIPTION
This allows the SXHKD_SHELL process to easily send signals to the parent sxhkd
process, for instance to break a chain by sending SIGALRM.  This was
previously somewhat difficult due to the double fork preventing the use of the
$PPID environment variable.