### PR TITLE
Hardcode the Mode_switch modifier as Mod5

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -33,7 +33,7 @@
 #include "parse.h"
 
 xcb_keysym_t Alt_L, Alt_R, Super_L, Super_R, Hyper_L, Hyper_R,
-             Meta_L, Meta_R, Mode_switch, Num_Lock, Scroll_Lock;
+             Meta_L, Meta_R, Num_Lock, Scroll_Lock;
 
 keysym_dict_t nks_dict[] = {/*{{{*/
 	{"VoidSymbol"                  , 0xffffff}   ,
@@ -2744,7 +2744,7 @@ bool parse_modifier(char *name, uint16_t *modfield)
 		*modfield |= (modfield_from_keysym(Meta_L) | modfield_from_keysym(Meta_R));
 		return true;
 	} else if (strcmp(name, "mode_switch") == 0) {
-		*modfield |= modfield_from_keysym(Mode_switch);
+		*modfield |= XCB_MOD_MASK_5;
 		return true;
 	} else if (strcmp(name, "mod1") == 0) {
 		*modfield |= XCB_MOD_MASK_1;
@@ -2802,7 +2802,6 @@ void get_standard_keysyms(void)
 	GETKS(Super_R)
 	GETKS(Hyper_L)
 	GETKS(Hyper_R)
-	GETKS(Mode_switch)
 	GETKS(Num_Lock)
 	GETKS(Scroll_Lock)
 #undef GETKS

--- a/src/types.c
+++ b/src/types.c
@@ -145,7 +145,7 @@ chord_t *make_chord(xcb_keysym_t keysym, xcb_button_t button, uint16_t modfield,
 				for (unsigned char col = 0; col < KEYSYMS_PER_KEYCODE; col++) {
 					xcb_keysym_t ks = xcb_key_symbols_get_keysym(symbols, *kc, col);
 					if (ks == keysym) {
-						uint16_t implicit_modfield = (col & 1 ? XCB_MOD_MASK_SHIFT : 0) | (col & 2 ? modfield_from_keysym(Mode_switch) : 0);
+						uint16_t implicit_modfield = (col & 1 ? XCB_MOD_MASK_SHIFT : 0) | (col & 2 ? XCB_MOD_MASK_5 : 0);
 						uint16_t explicit_modfield = modfield | implicit_modfield;
 						chord = malloc(sizeof(chord_t));
 						bool unique = true;

--- a/src/types.h
+++ b/src/types.h
@@ -34,8 +34,6 @@
 #define ESCAPE_KEYSYM        0xff1b
 #define SYNCHRONOUS_CHAR     ';'
 
-extern xcb_keysym_t Mode_switch;
-
 typedef struct chord_t chord_t;
 struct chord_t {
 	char repr[MAXLEN];


### PR DESCRIPTION
Following a change in xkeyboard-config 2.37, modfield_from_keysym(Mode_switch) returns 0 and we should assume that the modifier for mode switching is Mod5: https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/issues/363

Fixes https://github.com/baskerville/sxhkd/issues/289, fixes https://github.com/baskerville/sxhkd/issues/297, possibly fïxes https://github.com/baskerville/sxhkd/issues/291