### PR TITLE
debounce repeated keypresses on hold

### DIFF
--- a/doc/sxhkd.1
+++ b/doc/sxhkd.1
@@ -2,12 +2,12 @@
 .\"     Title: sxhkd
 .\"    Author: [see the "Author" section]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 11/19/2022
+.\"      Date: 07/22/2023
 .\"    Manual: Sxhkd Manual
-.\"    Source: Sxhkd 0.6.2-3-g56d3377
+.\"    Source: Sxhkd 0.6.2
 .\"  Language: English
 .\"
-.TH "SXHKD" "1" "11/19/2022" "Sxhkd 0\&.6\&.2\-3\-g56d3377" "Sxhkd Manual"
+.TH "SXHKD" "1" "07/22/2023" "Sxhkd 0\&.6\&.2" "Sxhkd Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -78,6 +78,11 @@ Output status information to the given FIFO\&.
 .RS 4
 Name of the keysym used for aborting chord chains\&.
 .RE
+.PP
+\fB\-d\fR \fIMS_DEBOUNCE\fR
+.RS 4
+Debounce time between key release and keypress events\&.
+.RE
 .SH "BEHAVIOR"
 .sp
 \fBsxhkd\fR is a daemon that listens to keyboard events and execute commands\&.
@@ -97,6 +102,8 @@ The commands are executed via \fBSHELL\fR \fI\-c\fR \fBCOMMAND\fR (hence you can
 \fBSXHKD_PID\fR will be automatically set to the pid of \fBsxhkd\fR in processes spawned by \fBsxhkd\fR, which may be used by the child process to send easily signals such as \fISIGALRM\fR to the correct instance of \fBsxhkd\fR\&.
 .sp
 If you have a non\-QWERTY keyboard or a non\-standard layout configuration, you should provide a \fICOUNT\fR of \fI1\fR to the \fB\-m\fR option or \fI\-1\fR (interpreted as infinity) if you constantly switch from one layout to the other (\fBsxhkd\fR ignores all mapping notify events by default because the majority of those events are pointless)\&.
+.sp
+Keeping a key pressed for a long time may cause the key to be released and pressed again, which causes a chord chain break\&. You can use the \fB\-d\fR option to set a debounce time between key release and keypress events\&.
 .SH "CONFIGURATION"
 .sp
 Each line of the configuration file is interpreted as so:

--- a/doc/sxhkd.1.asciidoc
+++ b/doc/sxhkd.1.asciidoc
@@ -48,6 +48,9 @@ Options
 *-a* _ABORT_KEYSYM_::
     Name of the keysym used for aborting chord chains.
 
+*-d* _MS_DEBOUNCE_::
+    Debounce time between key release and keypress events.
+
 
 Behavior
 --------
@@ -69,6 +72,8 @@ The commands are executed via *SHELL* _-c_ *COMMAND* (hence you can use environm
 *SXHKD_PID* will be automatically set to the pid of *sxhkd* in processes spawned by *sxhkd*, which may be used by the child process to send easily signals such as _SIGALRM_ to the correct instance of *sxhkd*.
 
 If you have a non-QWERTY keyboard or a non-standard layout configuration, you should provide a _COUNT_ of _1_ to the *-m* option or _-1_ (interpreted as infinity) if you constantly switch from one layout to the other (*sxhkd* ignores all mapping notify events by default because the majority of those events are pointless).
+
+Keeping a key pressed for a long time may cause the key to be released and pressed again, which causes a chord chain break. You can use the *-d* option to set a debounce time between key release and keypress events.
 
 
 Configuration

--- a/src/sxhkd.h
+++ b/src/sxhkd.h
@@ -74,5 +74,6 @@ void reload_cmd(void);
 void toggle_grab_cmd(void);
 void hold(int sig);
 void put_status(char c, const char *s);
+bool debounce(xcb_keysym_t keysym, uint8_t event_type);
 
 #endif

--- a/src/types.c
+++ b/src/types.c
@@ -29,6 +29,7 @@
 #include <unistd.h>
 #include "parse.h"
 #include "grab.h"
+#include "types.h"
 
 hotkey_t *find_hotkey(xcb_keysym_t keysym, xcb_button_t button, uint16_t modfield, uint8_t event_type, bool *replay_event)
 {
@@ -277,4 +278,14 @@ void destroy_chord(chord_t *chord)
 		c = n;
 	}
 	free(chord);
+}
+
+evt_record *make_record()
+{
+	evt_record *record = malloc(sizeof(struct evt_record));
+	record->keysym = XCB_NO_SYMBOL;
+	record->event_type = 0;
+	record->timestamp.tv_sec = 0;
+	record->timestamp.tv_usec = 0;
+	return record;
 }

--- a/src/types.h
+++ b/src/types.h
@@ -27,6 +27,7 @@
 
 #include <xcb/xcb_keysyms.h>
 #include <stdbool.h>
+#include <sys/time.h>
 #include "helpers.h"
 
 #define KEYSYMS_PER_KEYCODE  4
@@ -75,6 +76,13 @@ typedef struct {
 	xcb_keysym_t keysym;
 } keysym_dict_t;
 
+typedef struct evt_record evt_record;
+struct evt_record {
+	xcb_keysym_t keysym;
+	uint8_t event_type;
+	struct timeval timestamp;
+};
+
 hotkey_t *find_hotkey(xcb_keysym_t keysym, xcb_button_t button, uint16_t modfield, uint8_t event_type, bool *replay_event);
 bool match_chord(chord_t *chord, uint8_t event_type, xcb_keysym_t keysym, xcb_button_t button, uint16_t modfield);
 bool chains_interfere(chain_t* a, chain_t* b);
@@ -87,5 +95,6 @@ void add_hotkey(hotkey_t *hk);
 void abort_chain(void);
 void destroy_chain(chain_t *chain);
 void destroy_chord(chord_t *chord);
+evt_record *make_record();
 
 #endif


### PR DESCRIPTION
This resolves https://github.com/baskerville/sxhkd/issues/156 https://github.com/baskerville/sxhkd/issues/298 by discarding keypress events that happen a very small amount of time after a keyrelease event is received the same (debounce_ms).

I know this solution is not optimal.

Tested with `-d 10` and it seems to work fine, though it does not work with something like
```
alt + Return
alt + @Return
```
