### PR TITLE
Close log file fd before exec

### DIFF
--- a/src/helpers.c
+++ b/src/helpers.c
@@ -79,6 +79,7 @@ void execute(char *cmd[])
 	if (redir_fd != -1) {
 		dup2(redir_fd, STDOUT_FILENO);
 		dup2(redir_fd, STDERR_FILENO);
+		close(redir_fd);
 	}
 	execvp(cmd[0], cmd);
 	err("Spawning failed.\n");


### PR DESCRIPTION
Close the log file before the exec to avoid child processes from having this file descriptor open.

I lost a lot of work hours due to this as I was mimicking systemd's sockets, which assume that certain sockets will be at specific file descriptors, but because I was launching it from a shell spawned from a chain of processes coming from sxhkd the file descriptors were shifted up.

<img width="512" height="104" alt="image" src="https://github.com/user-attachments/assets/007de561-41d0-43ad-bcb2-8826c7175caf" />
