### PR TITLE
Example scripts: make them more portable,fix shebangs,chmod +x.

### DIFF
--- a/examples/background_shell/shell
+++ b/examples/background_shell/shell
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/usr/bin/env sh
 
 printf "(%s)&\n" "$2" | tmux load-buffer -
 tmux paste-buffer -t sxhkd

--- a/examples/notification/autostart
+++ b/examples/notification/autostart
@@ -1,3 +1,3 @@
-#! /bin/sh
+#!/usr/bin/env sh
 
 sxhkd_notify "$SXHKD_FIFO" &

--- a/examples/notification/sxhkd_notify
+++ b/examples/notification/sxhkd_notify
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/usr/bin/env sh
 
 [ $# -ne 1 ] && exit 1
 


### PR DESCRIPTION
* `env` makes script more portable by looking up `sh` in `$PATH`
* Space after shebang is illegal